### PR TITLE
Fix indentation after comment with colon

### DIFF
--- a/indent/python.vim
+++ b/indent/python.vim
@@ -172,9 +172,9 @@ function! GetPythonIndent(lnum)
         endif
     endif
 
-    " If the previous line ended with a colon, indent relative to
-    " statement start.
-    if pline =~ ':\s*$'
+    " If the previous line ended with a colon and is not a comment, indent
+    " relative to statement start.
+    if pline =~ ':\s*$' && pline !~ '^\s*#'
         return indent(sslnum) + &sw
     endif
 


### PR DESCRIPTION
Hi!

Currently, `GetPythonIndent` adds an indent after any line ending in a colon, but if a comment ends in a colon the next line should not be indented. I added a condition to check for a '#' at the start of the line. This seems to give me the desired behavior.

Cheers,

Joseph
