### PR TITLE
Better colon handling

### DIFF
--- a/indent/python.vim
+++ b/indent/python.vim
@@ -174,7 +174,7 @@ function! GetPythonIndent(lnum)
 
     " If the previous line ended with a colon and is not a comment, indent
     " relative to statement start.
-    if pline =~ ':\s*$' && pline !~ '^\s*#'
+    if pline =~ '^[^#]*:\s*\(#.*\)\?$'
         return indent(sslnum) + &sw
     endif
 


### PR DESCRIPTION
Previous version of the script was not handling cases like

if x == 2: # Some comment
<newline here>

properly. Now, it does.
