### PR TITLE
add basic test suite using vimrunner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem "vimrunner", "0.3.0"
+gem "rspec"

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -15,7 +15,7 @@ let b:did_indent = 1
 setlocal expandtab
 setlocal nolisp
 setlocal autoindent
-setlocal indentexpr=GetPythonIndent(v:lnum)
+setlocal indentexpr=GetPythonPEPIndent(v:lnum)
 setlocal indentkeys=!^F,o,O,<:>,0),0],0},=elif,=except
 
 let s:maxoff = 50
@@ -101,7 +101,7 @@ function! s:BlockStarter(lnum, block_start_re)
     return -1
 endfunction
 
-function! GetPythonIndent(lnum)
+function! GetPythonPEPIndent(lnum)
 
     " First line has indent 0
     if a:lnum == 1

--- a/spec/indent/indent_spec.rb
+++ b/spec/indent/indent_spec.rb
@@ -1,0 +1,83 @@
+require "spec_helper"
+
+describe "vim" do
+
+  before(:each) { vim.normal 'gg"_dG' }  # clear buffer
+
+  describe "when using the indent plugin" do
+    it "sets the indentexpr and indentkeys options" do
+      vim.command("set indentexpr?").should include "GetPythonPEPIndent("
+      vim.command("set indentkeys?").should include "=elif"
+    end
+
+    it "sets autoindent and expandtab" do
+      vim.command("set autoindent?").should match(/\s*autoindent/)
+      vim.command("set expandtab?").should match(/\s*expandtab/)
+    end
+  end
+
+  describe "when entering the first line" do
+    before { vim.feedkeys 'ipass' }
+
+    it "does not indent" do
+      proposed_indent.should == 0
+      indent.should == 0
+    end
+
+    it "does not indent when using '=='" do
+      vim.normal "=="
+      indent.should == 0
+    end
+  end
+
+  describe "when after a '(' that is at the end of its line" do
+    before { vim.feedkeys 'itest(\<CR>' }
+
+    it "indents by one level" do
+      proposed_indent.should == shiftwidth
+      vim.feedkeys 'something'
+      indent.should == shiftwidth
+      vim.normal '=='
+      indent.should == shiftwidth
+    end
+
+    it "puts the closing parenthesis at the same level" do
+      vim.feedkeys ')'
+      indent.should == 0
+    end
+  end
+
+  describe "when after an '(' that is followed by something" do
+    before { vim.feedkeys 'itest(something,\<CR>' }
+
+    it "lines up on following lines" do
+      indent.should == 5
+      vim.feedkeys 'more,\<CR>'
+      indent.should == 5
+    end
+
+    it "lines up the closing parenthesis" do
+      vim.feedkeys ')'
+      indent.should == 5
+    end
+
+    it "does not touch the closing parenthesis if it is already indented further" do
+      vim.feedkeys '  )'
+      indent.should == 7
+    end
+  end
+
+  def shiftwidth
+    @shiftwidth ||= vim.echo("exists('*shiftwidth') ? shiftwidth() : &sw").to_i
+  end
+  def tabstop
+    @tabstop ||= vim.echo("&tabstop").to_i
+  end
+  def indent
+    vim.echo("indent('.')").to_i
+  end
+  def proposed_indent
+    vim.echo("GetPythonPEPIndent(line('.'))").to_i
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,20 @@
+require 'vimrunner'
+require 'vimrunner/rspec'
+
+Vimrunner::RSpec.configure do |config|
+  config.reuse_server = true
+
+  config.start_vim do
+    vim = Vimrunner.start
+
+    plugin_path = File.expand_path('../..', __FILE__)
+
+    # add_plugin appends the path to the rtp... :(
+    # vim.add_plugin(plugin_path, 'indent/python.vim')
+
+    vim.command "set rtp^=#{plugin_path}"
+    vim.command "runtime indent/python.vim"
+
+    vim
+  end
+end


### PR DESCRIPTION
Hi, I finally got around to implement some basic tests. I ended up using [vimrunner](https://github.com/AndrewRadev/vimrunner). This has one failing test that works using my other pull request (#8). I will update the other pull request when this one is merged. I may also add further tests but wanted to get the basics merged first.
To run the tests use `bundle install` and then `bundle exec rspec`.

The failing test case is "indent by one level when after a '(' that is at the end of its line".

I renamed the function to `GetPythonPEPIndent` so I can check that our version is used instead of the vanilla implementation that is also called `GetPythonIndent`.
