### PR TITLE
Fix issue #5 and fix failing tests.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,3 +10,4 @@ It is currently maintained by Hynek Schlawack with the generous help of the foll
 - Joseph Irwin
 - Steve Losh
 - Sylvain Soliman
+- Hassan Kibirige

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,16 @@ Please:
 - Write [good commit messages].
 - Ideally, [squash] your commits, i.e. make your pull requests just one commit.
 
+About the tests:
+
+- They written in ruby using [vimrunner] which requires [rspec]
+- Add the tests to `spec/indent/indent_spec.rb`. Look at the `describe` blocks to get the hang of it.
+- Run the tests with the command `rspec spec/`
+
 Thank you for considering to contribute!
 
 
 [squash]: http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html
 [good commit messages]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[vimrunner]: https://github.com/AndrewRadev/vimrunner
+[rspec]: https://github.com/rspec/rspec

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -189,6 +189,13 @@ function! GetPythonPEPIndent(lnum)
         return -1
     endif
 
+    " If this line is dedented and the number of indent spaces is valid
+    " (multiple of the indentation size), trust the user
+    let dedent_size = thisindent - indent(plnum)
+    if dedent_size < 0 && thisindent % &sw == 0
+        return -1
+    endif
+
     " In all other cases, line up with the start of the previous statement.
     return indent(sslnum)
 endfunction

--- a/spec/indent/indent_spec.rb
+++ b/spec/indent/indent_spec.rb
@@ -30,22 +30,22 @@ describe "vim" do
     end
   end
 
-  # describe "when after a '(' that is at the end of its line" do
-  #   before { vim.feedkeys 'itest(\<CR>' }
+  describe "when after a '(' that is at the end of its line" do
+    before { vim.feedkeys 'itest(\<CR>' }
 
-  #   it "indents by one level" do
-  #     proposed_indent.should == shiftwidth
-  #     vim.feedkeys 'something'
-  #     indent.should == shiftwidth
-  #     vim.normal '=='
-  #     indent.should == shiftwidth
-  #   end
+    it "indents by one level" do
+      proposed_indent.should == shiftwidth
+      vim.feedkeys 'something'
+      indent.should == shiftwidth
+      vim.normal '=='
+      indent.should == shiftwidth
+    end
 
-  #   it "puts the closing parenthesis at the same level" do
-  #     vim.feedkeys ')'
-  #     indent.should == 0
-  #   end
-  # end
+    it "puts the closing parenthesis at the same level" do
+      vim.feedkeys ')'
+      indent.should == 0
+    end
+  end
 
   describe "when after an '(' that is followed by something" do
     before { vim.feedkeys 'itest(something,\<CR>' }
@@ -67,6 +67,36 @@ describe "vim" do
     end
   end
 
+  describe "when previous line ended with a colon" do
+     it "and it is a comment" do
+        vim.feedkeys 'i    # This is a comment:\<CR>'
+        indent.should == previous_indent
+     end
+
+     it "and it is not a comment" do
+        vim.feedkeys 'i    while True:\<CR>'
+        indent.should == previous_indent + shiftwidth
+     end
+  end
+
+  describe "when current line is dedented compared to previous line" do
+     before { vim.feedkeys 'i\<TAB>\<TAB>if x:\<CR>return True\<CR>\<ESC>' }
+     it "and current line has a valid indentation (Part 1)" do
+        vim.feedkeys '0i\<TAB>if y:'
+        proposed_indent.should == -1
+     end
+
+     it "and current line has a valid indentation (Part 2)" do
+        vim.feedkeys '0i\<TAB>\<TAB>if y:'
+        proposed_indent.should == -1
+     end
+
+     it "and current line has an invalid indentation" do
+        vim.feedkeys 'i    while True:\<CR>'
+        indent.should == previous_indent + shiftwidth
+     end
+  end
+
   def shiftwidth
     @shiftwidth ||= vim.echo("exists('*shiftwidth') ? shiftwidth() : &sw").to_i
   end
@@ -77,7 +107,15 @@ describe "vim" do
     vim.echo("indent('.')").to_i
   end
   def proposed_indent
-    vim.echo("GetPythonPEPIndent(line('.'))").to_i
+    line = vim.echo("line('.')")
+    col = vim.echo("col('.')")
+    indent_value = vim.echo("GetPythonPEPIndent(line('.'))").to_i
+    vim.command("call cursor(#{line}, #{col})")
+    return indent_value
+  end
+  def previous_indent
+    pline = vim.echo("line('.')").to_i - 1
+    vim.echo("indent('#{pline}')").to_i
   end
 end
 


### PR DESCRIPTION
## Issue #5

Do not inherit indentation of the previous line if the current line
has less indentation but is valid.
## Failing tests

Commented out in commit #6e60ef0. The tests were failing because
the indent function
    GetPythonPEPIndent()
can modify the cursor position. There is nothing wrong with that
consequence, vim takes that into account and restores the cursor
position. Therefore when we call the function we need to restore
the cursor position.
