### PR TITLE
Fix issue #5 (Correct indent after end of block)

### DIFF
--- a/indent/python.vim
+++ b/indent/python.vim
@@ -191,6 +191,13 @@ function! GetPythonPEPIndent(lnum)
         return -1
     endif
 
+    " If this line is dedented and the number of indent spaces is valid
+    " (multiple of the indentation size), trust the user
+    let dedent_size = thisindent - indent(plnum)
+    if dedent_size < 0 && thisindent % &sw == 0
+        return -1
+    endif
+
     " In all other cases, line up with the start of the previous statement.
     return indent(sslnum)
 endfunction

--- a/spec/indent/indent_spec.rb
+++ b/spec/indent/indent_spec.rb
@@ -91,6 +91,24 @@ describe "vim" do
     end
   end
 
+  describe "when current line is dedented compared to previous line" do
+     before { vim.feedkeys 'i\<TAB>\<TAB>if x:\<CR>return True\<CR>\<ESC>' }
+     it "and current line has a valid indentation (Part 1)" do
+        vim.feedkeys '0i\<TAB>if y:'
+        proposed_indent.should == -1
+     end
+
+     it "and current line has a valid indentation (Part 2)" do
+        vim.feedkeys '0i\<TAB>\<TAB>if y:'
+        proposed_indent.should == -1
+     end
+
+     it "and current line has an invalid indentation" do
+        vim.feedkeys 'i    while True:\<CR>'
+        indent.should == previous_indent + shiftwidth
+     end
+  end
+
   def shiftwidth
     @shiftwidth ||= vim.echo("exists('*shiftwidth') ? shiftwidth() : &sw").to_i
   end
@@ -99,6 +117,10 @@ describe "vim" do
   end
   def indent
     vim.echo("indent('.')").to_i
+  end
+  def previous_indent
+    pline = vim.echo("line('.')").to_i - 1
+    vim.echo("indent('#{pline}')").to_i
   end
   def proposed_indent
     line = vim.echo("line('.')")


### PR DESCRIPTION
## Problem

Given two adjacent blocks where the 2nd block has
an equal or smaller indentation level compared to the 1st
block. If the blocks are not separated by an empty line,
the 2nd block will be placed (indented) inside the 1st
block.

This changes the meaning of code that already adheres to the
pep8 standard.
## Solution

Do not inherit indentation of the previous line if the current line
has less indentation but is valid.
