### PR TITLE
run test cases for different sets of settings

### DIFF
--- a/spec/indent/indent_spec.rb
+++ b/spec/indent/indent_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "vim" do
+shared_examples_for "vim" do
 
   before(:each) { vim.normal 'gg"_dG' }  # clear buffer
 
@@ -86,7 +86,7 @@ describe "vim" do
     end
 
     it "indents relative to line above" do
-        vim.feedkeys 'i\tvalue = test + \\\\\<CR>'
+        vim.feedkeys 'i\<TAB>value = test + \\\\\<CR>'
         indent.should == shiftwidth * 2
     end
   end
@@ -131,3 +131,18 @@ describe "vim" do
   end
 end
 
+describe "vim when using width of 4" do
+  before {
+    vim.command("set sw=4 ts=4 sts=4 et")
+  }
+
+  it_behaves_like "vim"
+end
+
+describe "vim when using width of 8" do
+  before {
+    vim.command("set sw=8 ts=8 sts=8 et")
+  }
+
+  it_behaves_like "vim"
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,8 @@ require 'vimrunner'
 require 'vimrunner/rspec'
 
 Vimrunner::RSpec.configure do |config|
-  config.reuse_server = true
+  # FIXME: reuse_server = true seems to hang after a certain number of test cases
+  config.reuse_server = false
 
   config.start_vim do
     vim = Vimrunner.start


### PR DESCRIPTION
I think tests should be run for different sets of settings. I'm not sure if this is the way to go. But it works for now. The only downside is that vimrunner seemed to hang after a number of consecutive tests on my machine, so I had to disable `reuse_server`.
