### PR TITLE
Add a user configuration for the maxoff length

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,12 @@ With content already, it will be aligned to the opening parenthesis::
 
 Existing indentation (including ``0``) in multiline strings will be kept, so this setting only applies to the indentation of new/empty lines.
 
+python_pep8_indent_max_back_search
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you have an error re-indenting a large list or dict set ``g:python_pep8_indent_max_back_search`` to a larger number.
+This defaults to ``50``
+
 
 Notes
 -----

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -36,7 +36,11 @@ if !exists('g:python_pep8_indent_multiline_string')
     let g:python_pep8_indent_multiline_string = 0
 endif
 
-let s:maxoff = 50
+if !exists('g:python_pep_8_indent_max_back_search')
+    let s:maxoff = 50
+else
+    let s:maxoff = g:python_pep_8_indent_max_back_search
+endif
 let s:block_rules = {
             \ '^\s*elif\>': ['if', 'elif'],
             \ '^\s*except\>': ['try', 'except'],


### PR DESCRIPTION
Given that the maxoff seems to be a tradeoff between correctness and
performance, allow the user to change it based off their needs.

Closes #63