### PR TITLE
Add skipping brackets inside byte strings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.dockerignore
+.gitignore
+CONTRIBUTING.rst
+docker-compose.yml
+Dockerfile
+Gemfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .*.swp
+Gemfile.lock

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -7,7 +7,6 @@ I’ve collected a few tips to get you started.
 Please:
 
 - *Always* add tests for your code.
-- Add yourself to the AUTHORS.rst file in an alphabetical fashion by first name – no matter how big or small your changes are.
 - Write `good commit messages`_.
 
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -19,6 +19,9 @@ Running Tests
 - Run the tests with the command::
 
    $ rspec spec
+- Alternatively you can use Docker::
+
+   $ docker-compose run --rm rspec
 
 Thank you for considering to contribute!
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:2.4.0-slim
+RUN apt-get update && \
+    apt-get install -y vim-gtk xvfb && \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /vim-python-pep8-indent
+ADD Gemfile .
+RUN bundle install
+ADD . /vim-python-pep8-indent
+ENTRYPOINT ["sh", "-c", "xvfb-run rspec spec $@", "ignore"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  rspec:
+    build: .
+    volumes:
+    - .:/vim-python-pep8-indent

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -55,9 +55,10 @@ let s:stop_statement = '^\s*\(break\|continue\|raise\|return\|pass\)\>'
 
 " Skip strings and comments. Return 1 for chars to skip.
 " jedi* refers to syntax definitions from jedi-vim for call signatures, which
-" are inserted temporarily into the buffer.
+" are inserted temporarily into the buffer. hdima/python-syntax adds byte
+" strings.
 let s:skip_special_chars = 'synIDattr(synID(line("."), col("."), 0), "name") ' .
-            \ '=~? "\\vstring|comment|jedi\\S"'
+            \ '=~? "\\vstring|comment|bytes|jedi\\S"'
 
 let s:skip_after_opening_paren = 'synIDattr(synID(line("."), col("."), 0), "name") ' .
             \ '=~? "\\vcomment|jedi\\S"'

--- a/pythonbytes.vim
+++ b/pythonbytes.vim
@@ -1,0 +1,13 @@
+" Copy bytes from hdima/python-syntax so we can test without bundling the
+" whole thing.
+syn region pythonBytes start=+[bB]'+ skip=+\\\\\|\\'\|\\$+ excludenl end=+'+ end=+$+ keepend contains=pythonBytesError,pythonBytesContent,@Spell  
+syn region pythonBytes start=+[bB]"+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end=+$+ keepend contains=pythonBytesError,pythonBytesContent,@Spell  
+syn region pythonBytes start=+[bB]"""+ end=+"""+ keepend contains=pythonBytesError,pythonBytesContent,pythonDocTest2,pythonSpaceError,@Spell  
+syn region pythonBytes start=+[bB]'''+ end=+'''+ keepend contains=pythonBytesError,pythonBytesContent,pythonDocTest,pythonSpaceError,@Spell
+syn match pythonBytesError ".\+" display contained  
+syn match pythonBytesContent "[\u0000-\u00ff]\+" display contained contains=pythonBytesEscape,pythonBytesEscapeError
+syn match pythonBytesEscape +\\[abfnrtv'"\\]+ display contained
+syn match pythonBytesEscape "\\\o\o\=\o\=" display contained
+syn match pythonBytesEscapeError "\\\o\{,2}[89]" display contained
+syn match pythonBytesEscape "\\x\x\{2}" display contained
+syn match pythonBytesEscapeError "\\x\x\=\X" display contained

--- a/spec/indent/indent_spec.rb
+++ b/spec/indent/indent_spec.rb
@@ -76,6 +76,14 @@ shared_examples_for "vim" do
     end
   end
 
+  describe "when after an '[' that is inside a byte string" do
+    before { vim.feedkeys 'itest = b"["\<CR>' }
+
+    it "does not indent" do
+      indent.should == 0
+    end
+  end
+
   describe "when after an '{' that is followed by a comment" do
     before { vim.feedkeys 'imydict = {  # comment\<CR>' }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ Vimrunner::RSpec.configure do |config|
 
     vim.command "set rtp^=#{plugin_path}"
     vim.command "runtime syntax/python.vim"
+    vim.command "runtime pythonbytes.vim"
     vim.command "runtime indent/python.vim"
 
     def shiftwidth


### PR DESCRIPTION
hdima/python-syntax is popular and adds byte strings (`b'bytes not string'`). `s:skip_special_chars` needs updating with the new syntax Id otherwise brackets inside byte strings are not skipped.

I also added docker because using vimrunner on macOS is hard.