### PR TITLE
Keep tabstop at ftplugin or vimrc value.

### DIFF
--- a/indent/python.vim
+++ b/indent/python.vim
@@ -30,7 +30,6 @@ setlocal nolisp
 setlocal autoindent
 setlocal indentexpr=GetPythonPEPIndent(v:lnum)
 setlocal indentkeys=!^F,o,O,<:>,0),0],0},=elif,=except
-setlocal tabstop=4
 setlocal softtabstop=4
 setlocal shiftwidth=4
 


### PR DESCRIPTION
Non-standard tabstop shows up as incorrect indentation in
a code formatted with 8-character tabstops.  Leave it up to the
user to set non-standard tab stops in their vimrc or ftplugin.