### PR TITLE
Bug fix with unmatched pair in string on previous line

### DIFF
--- a/indent/python.vim
+++ b/indent/python.vim
@@ -96,7 +96,7 @@ function! s:pair_sort(x, y)
 endfunction
 
 let s:skip_search = 'synIDattr(synID(line("."), col("."), 0), "name") ' .		
-            \ '=~? "pythonSpaceError"'
+            \ '=~? "comment"'
 
 " Find backwards the closest open parenthesis/bracket/brace.
 function! s:find_opening_paren(...)
@@ -122,7 +122,7 @@ function! s:find_opening_paren(...)
 
     " Remove empty matches and return the type with the closest match
     call filter(positions, 'v:val[0]')
-    call filter(positions 'synIDattr(synID(v:val[0], v:val[1], 0), "name")) =~? "comment\\|string\\|error"')
+    call filter(positions '(synIDattr(synID(v:val[0], v:val[1], 0), "name")) !~? "comment\\|string\\|error\\|bytes")')
     call sort(positions, 's:pair_sort')
 
     return get(positions, -1, [0, 0])

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -75,9 +75,6 @@ if has('conceal')
 endif
 
 
-let s:skip_search = "synIDattr(synID(line('.'), col('.'), 0), 'name') " .
-            \ "=~? '\\(comment\\|Bytes\\|String\\)'"
-
 " Use 'shiftwidth()' instead of '&sw'.
 " (Since Vim patch 7.3.629, 'shiftwidth' can be set to 0 to follow 'tabstop').
 if exists('*shiftwidth')

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -95,6 +95,9 @@ function! s:pair_sort(x, y)
     endif
 endfunction
 
+let s:skip_search = 'synIDattr(synID(line("."), col("."), 0), "name") ' .		
+            \ '=~? "pythonSpaceError"'
+
 " Find backwards the closest open parenthesis/bracket/brace.
 function! s:find_opening_paren(...)
     " optional arguments: line and column (defaults to 1) to search around
@@ -109,9 +112,7 @@ function! s:find_opening_paren(...)
     let stopline = max([0, line('.') - s:maxoff])
 
     " Return if cursor is in a comment.
-    if match(synIDattr(synID(line('.'), col('.'), 0), 'name'), '\(comment\|Bytes\|String\|error\)')
-        return [0, 0]
-    endif
+    exe 'if' s:skip_search '| return [0, 0] | endif'
 
     let positions = []
     for p in s:paren_pairs
@@ -121,6 +122,7 @@ function! s:find_opening_paren(...)
 
     " Remove empty matches and return the type with the closest match
     call filter(positions, 'v:val[0]')
+    call filter(positions 'synIDattr(synID(v:val[0], v:val[1], 0), "name")) =~? "comment\\|string\\|error"')
     call sort(positions, 's:pair_sort')
 
     return get(positions, -1, [0, 0])

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -75,8 +75,8 @@ if has('conceal')
 endif
 
 
-let s:skip_search = 'synIDattr(synID(line("."), col("."), 0), "name") ' .
-            \ '=~? "comment"'
+let s:skip_search = "synIDattr(synID(line('.'), col('.'), 0), 'name') " .
+            \ "=~? '\\(comment\\|Bytes\\|String\\)'"
 
 " Use 'shiftwidth()' instead of '&sw'.
 " (Since Vim patch 7.3.629, 'shiftwidth' can be set to 0 to follow 'tabstop').
@@ -112,7 +112,9 @@ function! s:find_opening_paren(...)
     let stopline = max([0, line('.') - s:maxoff])
 
     " Return if cursor is in a comment.
-    exe 'if' s:skip_search '| return [0, 0] | endif'
+    if match(synIDattr(synID(line('.'), col('.'), 0), 'name'), '\(comment\|Bytes\|String\)')
+        return [0, 0]
+    endif
 
     let positions = []
     for p in s:paren_pairs
@@ -338,7 +340,8 @@ function! s:is_python_string(lnum, ...)
     let cols = a:0 ? type(a:1) != type([]) ? [a:1] : a:1 : range(1, linelen)
     for cnum in cols
         if match(map(synstack(a:lnum, cnum),
-                    \ 'synIDattr(v:val,"name")'), 'python\S*String') == -1
+                    \ 'synIDattr(v:val,"name")'), 'python\S*\(String\|Bytes\)') == -1
+            echom line . ' is not a string'
             return 0
         end
     endfor

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -109,7 +109,7 @@ function! s:find_opening_paren(...)
     let stopline = max([0, line('.') - s:maxoff])
 
     " Return if cursor is in a comment.
-    if match(synIDattr(synID(line('.'), col('.'), 0), 'name'), '\(comment\|Bytes\|String\)')
+    if match(synIDattr(synID(line('.'), col('.'), 0), 'name'), '\(comment\|Bytes\|String\|error\)')
         return [0, 0]
     endif
 
@@ -338,7 +338,6 @@ function! s:is_python_string(lnum, ...)
     for cnum in cols
         if match(map(synstack(a:lnum, cnum),
                     \ 'synIDattr(v:val,"name")'), 'python\S*\(String\|Bytes\)') == -1
-            echom line . ' is not a string'
             return 0
         end
     endfor


### PR DESCRIPTION
line with unmatched paren/bracket etc

```
reg = b'\\x1b\\[(\\d+;\\d+)m'
m = re.match(reg, start)
```
previously this would treat `[` on a previous line as a bracket that would be used to align the text on the next line as if this bracket should have a matched bracket. And would result in something like this.

```
reg = b'\\x1b\\[(\\d+;\\d+)m'
                          m = re.match(reg, start)
```

By the way, I've looked at the code and it's kinda awfull. Like instead of just finding parens with iteration it uses recursion and jumps over the file instead of using buffer indexing. Maybe this can be changed into using python ast module and define some rules about matching. You know, python indenting in python, instead of vimscript, seems more natural to me.