### PR TITLE
add g:python_pep8_indent_continuation_indent_width

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,15 @@ With content already, it will be aligned to the opening parenthesis::
 
 Existing indentation (including ``0``) in multiline strings will be kept, so this setting only applies to the indentation of new/empty lines.
 
+python_pep8_indent_continuation_indent_width
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This option specifies the indent width used for line continuations from a parenthesis/bracket/brace.
+
+.. code-block:: vim
+    let g:python_pep8_indent_continuation_indent_width = 4 " default
+    let g:python_pep8_indent_continuation_indent_width = "&sw * 2"
+    let g:python_pep8_indent_continuation_indent_width = 8
 
 Notes
 -----

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -38,6 +38,10 @@ if !exists('g:python_pep8_indent_multiline_string')
     let g:python_pep8_indent_multiline_string = 0
 endif
 
+if !exists('g:python_pep8_indent_continuation_indent_width')
+    let g:python_pep8_indent_continuation_indent_width = 4
+endif
+
 let s:maxoff = 50
 let s:block_rules = {
             \ '^\s*elif\>': ['if', 'elif'],
@@ -212,7 +216,7 @@ function! s:indent_like_opening_paren(lnum)
         if starts_with_closing_paren
             let res = base
         else
-            let res = base + s:sw()
+            let res = base + eval(g:python_pep8_indent_continuation_indent_width)
         endif
     else
         " Indent to match position of opening paren.


### PR DESCRIPTION
I did not touch the test cases as I am not familiar with ruby.