### PR TITLE
Empty lines indenting, pt. 2

### DIFF
--- a/indent/python.vim
+++ b/indent/python.vim
@@ -301,6 +301,13 @@ function! s:indent_like_previous_line(lnum)
 
     let empty = getline(a:lnum) =~# '^\s*$'
 
+    " Current and prev line are empty, next is not -> indent like next.
+    if empty && a:lnum > 1 &&
+          \ (getline(a:lnum - 1) =~# '^\s*$') &&
+          \ !(getline(a:lnum + 1) =~# '^\s*$')
+      return indent(a:lnum + 1)
+    endif
+
     " If the previous statement was a stop-execution statement or a pass
     if getline(start) =~# s:stop_statement
         " Remove one level of indentation if the user hasn't already dedented

--- a/spec/indent/indent_spec.rb
+++ b/spec/indent/indent_spec.rb
@@ -168,6 +168,20 @@ shared_examples_for "vim" do
     end
   end
 
+  describe "when an empty line is after empty line / before non-empty" do
+    it "is indented like the next line" do
+      vim.feedkeys 'idef a():\<CR>1\<CR>\<CR>\<CR>2\<ESC><<kcc'
+      indent.should == 0
+    end
+  end
+
+  describe "when an empty line is after empty line / before non-empty (nested)" do
+    it "is indented like the next line" do
+      vim.feedkeys 'idef a():\<CR>1\<CR>\<CR>\<CR>\<ESC>0i\<TAB>2\<ESC>kcc'
+      indent.should == shiftwidth
+    end
+  end
+
   describe "when line is empty inside a block following multi-line statement" do
     it "is indented like the previous line" do
       vim.feedkeys 'idef a():\<CR>x = (1 +\<CR>2)\<CR>\<CR>y\<ESC>kcc'


### PR DESCRIPTION
This improves one particular case -- when the current empty line is preceded by an empty line but followed by non-empty. This makes #81 less intrusive in case you're inserting spaces between functions etc.

E.g.:

```python
def a():
    x
*
def b():
    y
```

`i\<CR>` should not indent the line (behaviour before #81), whereas `S` should. (that's how a few IDEs like PyCharm do it)

As a more realistic example:

```python
class Foo:
    def __init__(self):
        x = 1
*
    def f(self):
        pass
```

Pressing `<CR>` will put cursor at indent of 4, while pressing `S` will indent it to 8.