### PR TITLE
Intermediate fix for indenting huge dicts

### DIFF
--- a/indent/python.vim
+++ b/indent/python.vim
@@ -44,7 +44,7 @@ let s:block_rules_multiple = {
             \ }
 " Pairs to look for when searching for opening parenthesis.
 " The value is the maximum offset in lines.
-let s:paren_pairs = {'()': 10, '[]': 100, '{}': 1000}
+let s:paren_pairs = {'()': 50, '[]': 100, '{}': 1000}
 
 " Maximum offset when looking for multiline statements (in round parenthesis).
 let s:maxoff_multiline_statement = 50

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -45,6 +45,10 @@ let s:block_rules_multiple = {
 " Pairs to look for when searching for opening parenthesis.
 " The value is the maximum offset in lines.
 let s:paren_pairs = {'()': 10, '[]': 100, '{}': 1000}
+
+" Maximum offset when looking for multiline statements (in round parenthesis).
+let s:maxoff_multiline_statement = 50
+
 if &filetype ==# 'pyrex' || &filetype ==# 'cython'
     let b:control_statement = '\v^\s*(class|def|if|while|with|for|except|cdef|cpdef)>'
 else
@@ -121,19 +125,21 @@ function! s:find_opening_paren(...)
     return nearest
 endfunction
 
-" Find the start of a multi-line statement
+" Find the start of a multi-line statement (based on surrounding parens).
 function! s:find_start_of_multiline_statement(lnum)
     let lnum = a:lnum
     while lnum > 0
+        " XXX: not tested?!
         if getline(lnum - 1) =~# '\\$'
             let lnum = prevnonblank(lnum - 1)
         else
-            let [paren_lnum, _] = s:find_opening_paren(lnum)
-            if paren_lnum < 1
-                return lnum
-            else
-                let lnum = paren_lnum
+            call cursor(lnum, 1)
+            let stopline = max([1, lnum - s:maxoff_multiline_statement])
+            let pos = searchpairpos('\V(', '', '\V)', 'bnW', s:skip_special_chars, stopline)
+            if pos[0]
+                return pos[0]
             endif
+            return lnum
         endif
     endwhile
 endfunction

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -109,18 +109,16 @@ function! s:find_opening_paren(...)
     " Return if cursor is in a comment.
     exe 'if' s:skip_search '| return [0, 0] | endif'
 
-    let positions = []
+    let nearest = [0, 0]
     for [p, maxoff] in items(s:paren_pairs)
-        let stopline = max([0, line('.') - maxoff])
-        call add(positions, searchpairpos(
-           \ '\V'.p[0], '', '\V'.p[1], 'bnW', s:skip_special_chars, stopline))
+        let stopline = max([0, line('.') - maxoff, nearest[0]])
+        let next = searchpairpos(
+           \ '\V'.p[0], '', '\V'.p[1], 'bnW', s:skip_special_chars, stopline)
+        if next[0] && (next[0] > nearest[0] || (next[0] == nearest[0] && next[1] > nearest[1]))
+            let nearest = next
+        endif
     endfor
-
-    " Remove empty matches and return the type with the closest match
-    call filter(positions, 'v:val[0]')
-    call sort(positions, 's:pair_sort')
-
-    return get(positions, -1, [0, 0])
+    return nearest
 endfunction
 
 " Find the start of a multi-line statement

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -34,7 +34,6 @@ if !exists('g:python_pep8_indent_multiline_string')
     let g:python_pep8_indent_multiline_string = 0
 endif
 
-let s:maxoff = 50
 let s:block_rules = {
             \ '^\s*elif\>': ['if', 'elif'],
             \ '^\s*except\>': ['try', 'except'],
@@ -43,7 +42,9 @@ let s:block_rules = {
 let s:block_rules_multiple = {
             \ '^\s*else\>': ['if', 'elif', 'for', 'try', 'except'],
             \ }
-let s:paren_pairs = ['()', '{}', '[]']
+" Pairs to look for when searching for opening parenthesis.
+" The value is the maximum offset in lines.
+let s:paren_pairs = {'()': 10, '[]': 100, '{}': 1000}
 if &filetype ==# 'pyrex' || &filetype ==# 'cython'
     let b:control_statement = '\v^\s*(class|def|if|while|with|for|except|cdef|cpdef)>'
 else
@@ -105,13 +106,12 @@ function! s:find_opening_paren(...)
         return ret
     endif
 
-    let stopline = max([0, line('.') - s:maxoff])
-
     " Return if cursor is in a comment.
     exe 'if' s:skip_search '| return [0, 0] | endif'
 
     let positions = []
-    for p in s:paren_pairs
+    for [p, maxoff] in items(s:paren_pairs)
+        let stopline = max([0, line('.') - maxoff])
         call add(positions, searchpairpos(
            \ '\V'.p[0], '', '\V'.p[1], 'bnW', s:skip_special_chars, stopline))
     endfor

--- a/spec/indent/indent_spec.rb
+++ b/spec/indent/indent_spec.rb
@@ -587,3 +587,67 @@ describe "vim for cython" do
       end
   end
 end
+
+describe "Handles far away opening parens" do
+  before { vim.feedkeys '\<ESC>ggdGifrom foo import (' }
+
+  it "indents by one level" do
+    vim.feedkeys '\<CR>'
+    proposed_indent.should == shiftwidth
+  end
+
+  it "indents by one level for 10 lines" do
+    vim.command('set paste | exe "norm 9o" | set nopaste')
+    vim.feedkeys '\<Esc>o'
+    indent.should == shiftwidth
+  end
+
+  it "indents by one level for 50 lines" do
+    vim.command('set paste | exe "norm 49o" | set nopaste')
+    vim.feedkeys '\<Esc>o'
+    indent.should == shiftwidth
+  end
+end
+
+describe "Handles far away opening square brackets" do
+  before { vim.feedkeys '\<ESC>ggdGibar = [' }
+
+  it "indents by one level" do
+    vim.feedkeys '\<CR>'
+    proposed_indent.should == shiftwidth
+  end
+
+  it "indents by one level for 10 lines" do
+    vim.command('set paste | exe "norm 9o" | set nopaste')
+    vim.feedkeys '\<Esc>o'
+    indent.should == shiftwidth
+  end
+
+  it "indents by one level for 100 lines" do
+    vim.command('set paste | exe "norm 99o" | set nopaste')
+    vim.feedkeys '\<Esc>o'
+    indent.should == shiftwidth
+  end
+end
+
+describe "Handles far away opening curly brackets" do
+  before { vim.feedkeys '\<ESC>ggdGijson = {' }
+
+  it "indents by one level" do
+    vim.feedkeys '\<CR>'
+    vim.feedkeys '\<Esc>o'
+    proposed_indent.should == shiftwidth
+  end
+
+  it "indents by one level for 10 lines" do
+    vim.command('set paste | exe "norm 9o" | set nopaste')
+    vim.feedkeys '\<Esc>o'
+    indent.should == shiftwidth
+  end
+
+  it "indents by one level for 1000 lines" do
+    vim.command('set paste | exe "norm 999o" | set nopaste')
+    vim.feedkeys '\<Esc>o'
+    indent.should == shiftwidth
+  end
+end


### PR DESCRIPTION
This uses different offsets for the type of pairs: '()' and '[]' will
only look for just 20 lines above, while 1000 lines are used for '{}',
which might be a huge dict.

Ref: https://github.com/Vimjas/vim-python-pep8-indent/pull/64.