### PR TITLE
tests: explicitly enable old "should" syntax to fix deprecation warnings

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,11 @@
 require 'vimrunner'
 require 'vimrunner/rspec'
 
+# Explicitly enable usage of "should".
+RSpec.configure do |config|
+    config.expect_with(:rspec) { |c| c.syntax = :should }
+end
+
 Vimrunner::RSpec.configure do |config|
   # Use a single Vim instance for the test suite. Set to false to use an
   # instance per test (slower, but can be easier to manage).


### PR DESCRIPTION
> Deprecation Warnings:
>
> Using `should` from rspec-expectations' old `:should` syntax without
> explicitly enabling the syntax is deprecated. Use the new `:expect`
> syntax or explicitly enable `:should` with `config.expect_with(:rspec) {
> |c| c.syntax = :should }` instead. Called from
> …/vim-python-pep8-indent/spec/indent/indent_spec.rb:141:in
> `block (3 levels) in <top (required)>'.