### PR TITLE
Add option for hanging closing brackets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,32 @@ With content already, it will be aligned to the opening parenthesis::
 
 Existing indentation (including ``0``) in multiline strings will be kept, so this setting only applies to the indentation of new/empty lines.
 
+g:python_pep8_indent_hang_closing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Control closing bracket indentation with ``python_pep8_indent_hang_closing``, set globally or per buffer.
+
+By default (set to ``0``), closing brackets line up with the opening line::
+
+   my_list = [
+       1, 2, 3,
+       4, 5, 6,
+   ]
+   result = some_function_that_takes_arguments(
+       'a', 'b', 'c',
+       'd', 'e', 'f',
+   )
+
+With ``python_pep8_indent_hang_closing = 1``, closing brackets line up with the items::
+
+   my_list = [
+       1, 2, 3,
+       4, 5, 6,
+       ]
+   result = some_function_that_takes_arguments(
+       'a', 'b', 'c',
+       'd', 'e', 'f',
+       )
 
 Notes
 -----

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -34,6 +34,10 @@ if !exists('g:python_pep8_indent_multiline_string')
     let g:python_pep8_indent_multiline_string = 0
 endif
 
+if !exists('g:python_pep8_indent_hang_closing')
+    let g:python_pep8_indent_hang_closing = 0
+endif
+
 let s:block_rules = {
             \ '^\s*elif\>': ['if', 'elif'],
             \ '^\s*except\>': ['try', 'except'],
@@ -203,8 +207,11 @@ function! s:indent_like_opening_paren(lnum)
                 \ s:skip_after_opening_paren, paren_lnum, paren_col+1)
     let starts_with_closing_paren = getline(a:lnum) =~# '^\s*[])}]'
 
+    let hang_closing = get(b:, 'python_pep8_indent_hang_closing',
+                \ get(g:, 'python_pep8_indent_hang_closing', 0))
+
     if nothing_after_opening_paren
-        if starts_with_closing_paren
+        if starts_with_closing_paren && !hang_closing
             let res = base
         else
             let res = base + s:sw()

--- a/spec/indent/indent_spec.rb
+++ b/spec/indent/indent_spec.rb
@@ -52,7 +52,7 @@ shared_examples_for "vim" do
 
     it "puts the closing parenthesis at the same level" do
       vim.feedkeys ')'
-      indent.should == 0
+      indent.should == (hang_closing ? shiftwidth : 0)
     end
   end
 
@@ -87,7 +87,7 @@ shared_examples_for "vim" do
 
     it "lines up the closing parenthesis" do
       vim.feedkeys '}'
-      indent.should == 0
+      indent.should == (hang_closing ? shiftwidth : 0)
     end
   end
 
@@ -514,18 +514,31 @@ shared_examples_for "multiline strings" do
   end
 end
 
-describe "vim when using width of 4" do
-  before {
-    vim.command("set sw=4 ts=4 sts=4 et")
-  }
-  it_behaves_like "vim"
-end
+SUITE_SHIFTWIDTHS = [4, 3]
+SUITE_HANG_CLOSINGS = [nil, false, true]
 
-describe "vim when using width of 3" do
-  before {
-    vim.command("set sw=3 ts=3 sts=3 et")
-  }
-  it_behaves_like "vim"
+SUITE_SHIFTWIDTHS.each do |sw|
+  describe "vim when using width of #{sw}" do
+    before {
+      vim.command("set sw=#{sw} ts=#{sw} sts=#{sw} et")
+    }
+    it "sets shiftwidth to #{sw}" do
+      shiftwidth.should == sw
+    end
+
+    SUITE_HANG_CLOSINGS.each do |hc|
+      describe "vim when hang_closing is set to #{hc}" do
+        before {
+          set_hang_closing hc
+        }
+        it "sets hang_closing to #{hc}" do
+          hang_closing.should == !!hc
+        end
+
+        it_behaves_like "vim"
+      end
+    end
+  end
 end
 
 describe "vim when not using python_pep8_indent_multiline_string" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,18 @@ Vimrunner::RSpec.configure do |config|
       i = vim.echo("get(g:, 'python_pep8_indent_multiline_string', 0)").to_i
       return (i == -2 ? default : i), i < 0 ? (i == -1 ? prev : default) : i
     end
+    def hang_closing
+      i = vim.echo("get(g:, 'python_pep8_indent_hang_closing', 0)").to_i
+      return (i != 0)
+    end
+    def set_hang_closing(value)
+      if value.nil?
+        vim.command("unlet! g:python_pep8_indent_hang_closing")
+      else
+        i = value ? 1 : 0
+        vim.command("let g:python_pep8_indent_hang_closing=#{i}")
+      end
+    end
 
     vim
   end


### PR DESCRIPTION
The main idea is discussed at length in PyCQA/pycodestyle#103.

It allows this style:
```python
my_list = [
    1, 2, 3,
    4, 5, 6,
    ]

result = some_function_that_takes_arguments(
    'a', 'b', 'c',
    'd', 'e', 'f',
    )
```

A similar option was added to pycodestyle / pep8 awhile ago. See PyCQA/pycodestyle#207.