### PR TITLE
tests: remove nil from hang-closing tests

### DIFF
--- a/spec/indent/indent_spec.rb
+++ b/spec/indent/indent_spec.rb
@@ -515,7 +515,7 @@ shared_examples_for "multiline strings" do
 end
 
 SUITE_SHIFTWIDTHS = [4, 3]
-SUITE_HANG_CLOSINGS = [nil, false, true]
+SUITE_HANG_CLOSINGS = [false, true]
 
 SUITE_SHIFTWIDTHS.each do |sw|
   describe "vim when using width of #{sw}" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,12 +52,8 @@ Vimrunner::RSpec.configure do |config|
       return (i != 0)
     end
     def set_hang_closing(value)
-      if value.nil?
-        vim.command("unlet! g:python_pep8_indent_hang_closing")
-      else
-        i = value ? 1 : 0
-        vim.command("let g:python_pep8_indent_hang_closing=#{i}")
-      end
+      i = value ? 1 : 0
+      vim.command("let g:python_pep8_indent_hang_closing=#{i}")
     end
 
     vim


### PR DESCRIPTION
There is not much value in running all tests with it to see that the
default is used.