### PR TITLE
Handle byte strings in s:skip_special_chars

### DIFF
--- a/indent/python.vim
+++ b/indent/python.vim
@@ -61,7 +61,7 @@ let s:stop_statement = '^\s*\(break\|continue\|raise\|return\|pass\)\>'
 " jedi* refers to syntax definitions from jedi-vim for call signatures, which
 " are inserted temporarily into the buffer.
 let s:skip_special_chars = 'synIDattr(synID(line("."), col("."), 0), "name") ' .
-            \ '=~? "\\vstring|comment|jedi\\S"'
+            \ '=~? "\\vstring|comment|pythonbytes|jedi\\S"'
 
 let s:skip_after_opening_paren = 'synIDattr(synID(line("."), col("."), 0), "name") ' .
             \ '=~? "\\vcomment|jedi\\S"'

--- a/spec/indent/bytes_spec.rb
+++ b/spec/indent/bytes_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+describe "handles byte strings" do
+  before(:all) {
+      vim.command 'syn region pythonBytes start=+[bB]"+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end=+$+ keepend contains=pythonBytesError,pythonBytesContent,@Spell'
+  }
+
+  before(:each) {
+    # clear buffer
+    vim.normal 'gg"_dG'
+
+    # Insert two blank lines.
+    # The first line is a corner case in this plugin that would shadow the
+    # correct behaviour of other tests. Thus we explicitly jump to the first
+    # line when we require so.
+    vim.feedkeys 'i\<CR>\<CR>\<ESC>'
+  }
+
+  it "it does not indent to bracket in byte string" do
+    vim.feedkeys 'ireg = b"["\<Esc>'
+    vim.echo('map(synstack(line("."), col(".")), "synIDattr(v:val, \"name\")")'
+            ).should == "['pythonBytes']"
+    vim.feedkeys 'o'
+    indent.should == 0
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/Vimjas/vim-python-pep8-indent/issues/72.
Closes https://github.com/Vimjas/vim-python-pep8-indent/pull/71.
Closes https://github.com/Vimjas/vim-python-pep8-indent/pull/68.