### PR TITLE
Fix handling of pythonBytesEscape from vim-python/python-syntax

### DIFF
--- a/indent/python.vim
+++ b/indent/python.vim
@@ -61,7 +61,7 @@ let s:stop_statement = '^\s*\(break\|continue\|raise\|return\|pass\)\>'
 " jedi* refers to syntax definitions from jedi-vim for call signatures, which
 " are inserted temporarily into the buffer.
 let s:skip_special_chars = 'synIDattr(synID(line("."), col("."), 0), "name") ' .
-            \ '=~? "\\vstring|comment|pythonbytes|jedi\\S"'
+            \ '=~? "\\vstring|comment|^pythonbytes%(contents)=$|jedi\\S"'
 
 let s:skip_after_opening_paren = 'synIDattr(synID(line("."), col("."), 0), "name") ' .
             \ '=~? "\\vcomment|jedi\\S"'

--- a/spec/indent/bytes_spec.rb
+++ b/spec/indent/bytes_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 describe "handles byte strings" do
   before(:all) {
       vim.command 'syn region pythonBytes start=+[bB]"+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end=+$+ keepend contains=pythonBytesError,pythonBytesContent,@Spell'
+      vim.command "syn match pythonBytesEscape       '\\\\$'"
   }
 
   before(:each) {
@@ -22,5 +23,14 @@ describe "handles byte strings" do
             ).should == "['pythonBytes']"
     vim.feedkeys 'o'
     indent.should == 0
+  end
+
+  it "it indents backslash continuation correctly" do
+    vim.feedkeys 'iwith foo, \<Bslash>\<Esc>'
+    vim.echo('getline(".")').should == "with foo, \\"
+    vim.echo('map(synstack(line("."), col(".")), "synIDattr(v:val, \"name\")")'
+            ).should == "['pythonBytesEscape']"
+    vim.feedkeys 'o'
+    indent.should == 8
   end
 end


### PR DESCRIPTION
Fixes https://github.com/Vimjas/vim-python-pep8-indent/issues/114