### PR TITLE
Fix indent with pythonTodo at end of line

### DIFF
--- a/indent/python.vim
+++ b/indent/python.vim
@@ -69,13 +69,15 @@ let s:stop_statement = '^\s*\(break\|continue\|raise\|return\|pass\)\>'
 let s:skip_after_opening_paren = 'synIDattr(synID(line("."), col("."), 0), "name") ' .
             \ '=~? "\\vcomment|jedi\\S"'
 
+let s:special_chars_syn_pattern = "\\vstring|comment|^pythonbytes%(contents)=$|pythonTodo|jedi\\S"
+
 if !get(g:, 'python_pep8_indent_skip_concealed', 0) || !has('conceal')
     " Skip strings and comments. Return 1 for chars to skip.
     " jedi* refers to syntax definitions from jedi-vim for call signatures, which
     " are inserted temporarily into the buffer.
     function! s:_skip_special_chars(line, col)
         return synIDattr(synID(a:line, a:col, 0), 'name')
-                \ =~? "\\vstring|comment|^pythonbytes%(contents)=$|jedi\\S"
+              \ =~? s:special_chars_syn_pattern
     endfunction
 else
     " Also ignore anything concealed.
@@ -90,8 +92,8 @@ else
 
     function! s:_skip_special_chars(line, col)
         return synIDattr(synID(a:line, a:col, 0), 'name')
-                \ =~? "\\vstring|comment|^pythonbytes%(contents)=$|jedi\\S"
-                \ || s:is_concealed(a:line, a:col)
+              \ =~? s:special_chars_syn_pattern
+              \ || s:is_concealed(a:line, a:col)
     endfunction
 endif
 

--- a/spec/indent/indent_spec.rb
+++ b/spec/indent/indent_spec.rb
@@ -727,3 +727,16 @@ describe "searchpairpos" do
     indent.should == shiftwidth
   end
 end
+
+describe "o within TODO" do
+  before {
+    vim.feedkeys 'iif 1:  # TODO\<Esc>'
+    # Assertion that we have a pythonTodo here.
+    vim.echo('synIDattr(synID(line("."), col("."), 0), "name")').should match 'pythonTodo'
+  }
+
+  it "respects autoindent" do
+    vim.feedkeys 'o'
+    indent.should == shiftwidth
+  end
+end

--- a/spec/indent/indent_spec.rb
+++ b/spec/indent/indent_spec.rb
@@ -702,7 +702,10 @@ describe "Compact multiline dict" do
 end
 
 describe "Using O" do
-  before { vim.feedkeys 'iif foo:\<CR>' }
+  before {
+    vim.feedkeys '\<ESC>ggdG'
+    vim.feedkeys 'iif foo:\<CR>'
+  }
 
   it "respects autoindent" do
     vim.feedkeys '1\<CR>\<CR>'
@@ -730,6 +733,7 @@ end
 
 describe "o within TODO" do
   before {
+    vim.feedkeys '\<ESC>ggdG'
     vim.feedkeys 'iif 1:  # TODO\<Esc>'
     # Assertion that we have a pythonTodo here.
     vim.echo('synIDattr(synID(line("."), col("."), 0), "name")').should match 'pythonTodo'


### PR DESCRIPTION
"pythonTodo" is contained in "pythonComment".
Fix it by adding "pythonTodo" to the pattern to match special chars.

An alternative might be using `synstack()` to get to "pythonComment"
still, but this is not really necessary (and likely slower).