### PR TITLE
Use only one level of indentation after opening paren

### DIFF
--- a/indent/python.vim
+++ b/indent/python.vim
@@ -212,7 +212,7 @@ function! s:indent_like_opening_paren(lnum)
         if starts_with_closing_paren && !hang_closing
             let res = base
         else
-            let res = base + s:sw()
+            return base + s:sw()
         endif
     else
         " Indent to match position of opening paren.

--- a/spec/indent/cython_spec.rb
+++ b/spec/indent/cython_spec.rb
@@ -23,14 +23,14 @@ describe "vim for cython" do
   describe "when using a cdef function definition" do
       it "indents shiftwidth spaces" do
           vim.feedkeys 'icdef long_function_name(\<CR>arg'
-          indent.should == shiftwidth * 2
+          indent.should == shiftwidth
       end
   end
 
   describe "when using a cpdef function definition" do
       it "indents shiftwidth spaces" do
           vim.feedkeys 'icpdef long_function_name(\<CR>arg'
-          indent.should == shiftwidth * 2
+          indent.should == shiftwidth
       end
   end
 end

--- a/spec/indent/indent_spec.rb
+++ b/spec/indent/indent_spec.rb
@@ -205,14 +205,14 @@ shared_examples_for "vim" do
   describe "when using a function definition" do
       it "indents shiftwidth spaces" do
           vim.feedkeys 'idef long_function_name(\<CR>arg'
-          indent.should == shiftwidth * 2
+          indent.should == shiftwidth
       end
   end
 
   describe "when using a class definition" do
       it "indents shiftwidth spaces" do
           vim.feedkeys 'iclass Foo(\<CR>'
-          indent.should == shiftwidth * 2
+          indent.should == shiftwidth
       end
   end
 
@@ -430,7 +430,7 @@ shared_examples_for "vim" do
 
     it "ignores the call signature after a function" do
       vim.feedkeys 'idef f(  JEDI_CALL_SIGNATURE\<CR>'
-      indent.should == shiftwidth * 2
+      indent.should == shiftwidth
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/Vimjas/vim-python-pep8-indent/issues/126.