### PR TITLE
Fix indent of "elif" after "else"

### DIFF
--- a/indent/python.vim
+++ b/indent/python.vim
@@ -48,13 +48,13 @@ if !exists('g:python_pep8_indent_searchpair_timeout')
 endif
 
 let s:block_rules = {
-            \ '^\s*elif\>': ['if', 'elif'],
-            \ '^\s*except\>': ['try', 'except'],
-            \ '^\s*finally\>': ['try', 'except', 'else']
-            \ }
+      \ '^\s*elif\>': [['if', 'elif'], ['else']],
+      \ '^\s*except\>': [['try', 'except'], []],
+      \ '^\s*finally\>': [['try', 'except', 'else'], []]
+      \ }
 let s:block_rules_multiple = {
-            \ '^\s*else\>': ['if', 'elif', 'for', 'try', 'except'],
-            \ }
+      \ '^\s*else\>': [['if', 'elif', 'for', 'try', 'except'], []]
+      \ }
 " Pairs to look for when searching for opening parenthesis.
 " The value is the maximum offset in lines.
 let s:paren_pairs = {'()': 50, '[]': 100, '{}': 1000}
@@ -150,15 +150,23 @@ function! s:find_start_of_multiline_statement(lnum)
 endfunction
 
 " Find possible indent(s) of the block starter that matches the current line.
-function! s:find_start_of_block(lnum, types, multiple)
+function! s:find_start_of_block(lnum, types, skip, multiple) abort
     let r = []
     let re = '\V\^\s\*\('.join(a:types, '\|').'\)\>'
+    if !empty(a:skip)
+      let re_skip = '\V\^\s\*\('.join(a:skip, '\|').'\)\>'
+    else
+      let re_skip = ''
+    endif
     let lnum = a:lnum
     let last_indent = indent(lnum) + 1
     while lnum > 0 && last_indent > 0
         let indent = indent(lnum)
         if indent < last_indent
-            if getline(lnum) =~# re
+            let line = getline(lnum)
+            if !empty(re_skip) && line =~# re_skip
+                let last_indent = indent
+            elseif line =~# re
                 if !a:multiple
                     return [indent]
                 endif
@@ -239,13 +247,16 @@ function! s:indent_like_block(lnum)
     let text = getline(a:lnum)
     for [multiple, block_rules] in [
                 \ [0, s:block_rules],
-                \ [1, s:block_rules_multiple]]
-        for [line_re, blocks] in items(block_rules)
+                \ [1, s:block_rules_multiple],
+                \ ]
+        for [line_re, blocks_ignore] in items(block_rules)
             if text !~# line_re
                 continue
             endif
 
-            let indents = s:find_start_of_block(a:lnum - 1, blocks, multiple)
+            let [blocks, skip] = blocks_ignore
+
+            let indents = s:find_start_of_block(a:lnum - 1, blocks, skip, multiple)
             if !len(indents)
                 return -1
             endif

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -255,9 +255,8 @@ function! s:indent_like_block(lnum)
             endif
 
             let [blocks, skip] = blocks_ignore
-
             let indents = s:find_start_of_block(a:lnum - 1, blocks, skip, multiple)
-            if !len(indents)
+            if empty(indents)
                 return -1
             endif
             if len(indents) == 1

--- a/spec/indent/indent_spec.rb
+++ b/spec/indent/indent_spec.rb
@@ -744,3 +744,14 @@ describe "o within TODO" do
     indent.should == shiftwidth
   end
 end
+
+describe "elif ignores previous else" do
+  before {
+    vim.feedkeys '\<ESC>ggdG'
+  }
+
+  it "respects autoindent" do
+    vim.feedkeys 'iif 1:\<CR>if 2:\<CR>pass\<CR>else:\<CR>pass\<CR>elif 3:\<Esc>'
+    indent.should == 0
+  end
+end

--- a/spec/indent/indent_spec.rb
+++ b/spec/indent/indent_spec.rb
@@ -745,13 +745,17 @@ describe "o within TODO" do
   end
 end
 
-describe "elif ignores previous else" do
+describe "elif after else" do
   before {
     vim.feedkeys '\<ESC>ggdG'
   }
 
-  it "respects autoindent" do
+  it "is indented to the outer if" do
     vim.feedkeys 'iif 1:\<CR>if 2:\<CR>pass\<CR>else:\<CR>pass\<CR>elif 3:\<Esc>'
     indent.should == 0
+
+    vim.feedkeys '\<ESC>ggdG'
+    vim.feedkeys 'i    if 1:\<CR>if 2:\<CR>pass\<CR>else:\<CR>pass\<CR>elif 3:\<Esc>'
+    indent.should == 4
   end
 end


### PR DESCRIPTION
Fixes https://github.com/Vimjas/vim-python-pep8-indent/issues/125.