### PR TITLE
The indent script is never executed because the built-in runtime indent script 'indent/python.vim' modifies the variable 'b:did_indent'

### DIFF
--- a/indent/python.vim
+++ b/indent/python.vim
@@ -20,9 +20,10 @@
 " <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 " Only load this indent file when no other was loaded.
-if exists('b:did_indent')
+if exists('b:did_python_pep8_indent')
     finish
 endif
+let b:did_python_pep8_indent = 1
 let b:did_indent = 1
 
 setlocal nolisp


### PR DESCRIPTION
The indent script `vim-python-pep8-indent/indent/python.vim` is never executed because the built-in runtime indent script [vim/runtime/indent/python.vim](https://github.com/vim/vim/blob/master/runtime/indent/python.vim) assigns 1 to the variable `b:did_indent`, which is the same variable that the indent plugin 'vim-python-pep8-indent' uses.

This pull request replaces the variable `b:did_indent` with `b:did_python_pep8_indent`.