### PR TITLE
Fix typo in bytes literal syntax group name

### DIFF
--- a/indent/python.vim
+++ b/indent/python.vim
@@ -69,7 +69,7 @@ let s:stop_statement = '^\s*\(break\|continue\|raise\|return\|pass\)\>'
 let s:skip_after_opening_paren = 'synIDattr(synID(line("."), col("."), 0), "name") ' .
             \ '=~? "\\vcomment|jedi\\S"'
 
-let s:special_chars_syn_pattern = "\\vstring|comment|^pythonbytes%(contents)=$|pythonTodo|jedi\\S"
+let s:special_chars_syn_pattern = "\\vstring|comment|^pythonbytes%(content)=$|pythonTodo|jedi\\S"
 
 if !get(g:, 'python_pep8_indent_skip_concealed', 0) || !has('conceal')
     " Skip strings and comments. Return 1 for chars to skip.


### PR DESCRIPTION
Should fix #140.

Github code search returns >120 files for "pythonbytescontent" (mostly copies of https://github.com/vim-python/python-syntax), but none for "pythonbytescontents". 